### PR TITLE
Ganglia input: Store the value and ganglia name.

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -111,8 +111,9 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       # Check if it was a valid data request
       return nil unless data
-      props={ "program" => "ganglia", "log_host" => data["hostname"] }
-      %w{dmax tmax slope type units}.each do |info|
+      props={ "program" => "ganglia", "log_host" => data["hostname"],
+              "val" => data["val"] }
+      %w{dmax tmax slope type units name}.each do |info|
         props[info] = @metadata[data["name"]][info]
       end
       return LogStash::Event.new(props)

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -36,7 +36,7 @@ describe LogStash::Inputs::Ganglia do
       {  :name => 'pageviews',
          :units => 'req/min',
          :type => 'uint8',
-         :value => 7000,
+         :val => 7000,
          :tmax => 60,
          :dmax => 300,
          :group => 'test' }
@@ -60,6 +60,14 @@ describe LogStash::Inputs::Ganglia do
 
     it "should receive the correct data" do
       expect(event["tmax"]).to eq(60)
+    end
+
+    it "should receive the name" do
+      expect(event["name"]).to eq('pageviews')
+    end
+
+    it "should receive the value" do
+      expect(event["val"]).to eq(7000)
     end
 
   end


### PR DESCRIPTION
Ganglia input: Store the value and ganglia name.

Previously, we only had metadata in events. An event would look like
this:

```ruby
{
      "@version" => "1",
    "@timestamp" => "2014-09-22T10:51:59.337Z",
      "log_host" => "example.com",
          "dmax" => 0,
          "tmax" => 90,
         "slope" => "both",
          "type" => "float",
         "units" => "%",
          "host" => "1.2.3.4"
}
```

Events now look like this:

```ruby
{
      "@version" => "1",
    "@timestamp" => "2014-09-22T10:51:59.337Z",
      "log_host" => "example.com",
           "val" => 0.0, # added
          "dmax" => 0,
          "tmax" => 90,
         "slope" => "both",
          "type" => "float",
         "units" => "%",
          "name" => "cpu_nice", # added
          "host" => "1.2.3.4"
}
```