### PR TITLE
Adding ganglia metric name and value to the data

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -114,6 +114,8 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       data["program"] = "ganglia"
       event["log_host"] = data["hostname"]
+      event["name"] = data["name"]
+      event["val"] = data["val"]
       %w{dmax tmax slope type units}.each do |info|
         event[info] = @metadata[data["name"]][info]
       end

--- a/lib/logstash/inputs/ganglia/gmondpacket.rb
+++ b/lib/logstash/inputs/ganglia/gmondpacket.rb
@@ -112,22 +112,28 @@ class GmonPacket
   # Parsing a specific value of type
   # https://github.com/ganglia/monitor-core/blob/master/gmond/gmond.c#L1527
   def parse_value(type)
+	# We does not need to parse data by type because it receive data as string
+	# https://github.com/ganglia/monitor-core/blob/c74feb0e96d5a3efc3c788b37c113520234ab717/gmond/gmond.c#L1796
+	# https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-python/gmetric.py#L138
+	# https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-java/src/java/info/ganglia/metric/type/GMetricFloat.java#L97
+    local_value=@xdr.string
+
     value=:unknown
     case type
     when "int16"
-      value=@xdr.int16
+      value=local_value.to_i
     when "uint16"
-      value=@xdr.uint16
+      value=local_value.to_i
     when "uint32"
-      value=@xdr.uint32
+      value=local_value.to_i
     when "int32"
-      value=@xdr.int32
+      value=local_value.to_i
     when "float"
-      value=@xdr.float32
+      value=local_value.to_f
     when "double"
-      value=@xdr.float64
+      value=local_value.to_f
     when "string"
-      value=@xdr.string
+      value=local_value
     else
       #puts "Received unknown type #{type}"
     end


### PR DESCRIPTION
because it doesn't represent to the data by default.
And I fixed a little problem when parsing the gmond packet because the gmond packet is always sent as string whatever it data type is.

You can see it below:
* https://github.com/ganglia/monitor-core/blob/c74feb0e96d5a3efc3c788b37c113520234ab717/gmond/gmond.c#L1796 
* https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-java/src/java/info/ganglia/metric/type/GMetricFloat.java#L97
* https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-python/gmetric.py#L138