### PR TITLE
handle data type properly

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -114,6 +114,8 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       data["program"] = "ganglia"
       event["log_host"] = data["hostname"]
+      event["name"] = data["name"]
+      event["val"] = data["val"]
       %w{dmax tmax slope type units}.each do |info|
         event[info] = @metadata[data["name"]][info]
       end

--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -111,8 +111,9 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       # Check if it was a valid data request
       return nil unless data
-      props={ "program" => "ganglia", "log_host" => data["hostname"] }
-      %w{dmax tmax slope type units}.each do |info|
+      props={ "program" => "ganglia", "log_host" => data["hostname"],
+              "val" => data["val"] }
+      %w{dmax tmax slope type units name}.each do |info|
         props[info] = @metadata[data["name"]][info]
       end
       return LogStash::Event.new(props)

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -36,7 +36,7 @@ describe LogStash::Inputs::Ganglia do
       {  :name => 'pageviews',
          :units => 'req/min',
          :type => 'uint8',
-         :val => 7000,
+         :value => 7000,
          :tmax => 60,
          :dmax => 300,
          :group => 'test' }
@@ -66,7 +66,7 @@ describe LogStash::Inputs::Ganglia do
     end
 
     it "should receive the value" do
-      expect(event["val"]).to eq(7000)
+      expect(event["val"]).to eq('7000')
     end
 
   end

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -36,7 +36,7 @@ describe LogStash::Inputs::Ganglia do
       {  :name => 'pageviews',
          :units => 'req/min',
          :type => 'uint8',
-         :value => 7000,
+         :val => 7000,
          :tmax => 60,
          :dmax => 300,
          :group => 'test' }
@@ -60,6 +60,14 @@ describe LogStash::Inputs::Ganglia do
 
     it "should receive the correct data" do
       expect(event["tmax"]).to eq(60)
+    end
+
+    it "should receive the name" do
+      expect(event["name"]).to eq('pageviews')
+    end
+
+    it "should receive the value" do
+      expect(event["val"]).to eq(7000)
     end
 
   end

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -61,6 +61,10 @@ describe LogStash::Inputs::Ganglia do
       expect(event["tmax"]).to eq(60)
     end
 
+    it "should receive the correct data type" do
+      expect(event["type"]).to eq('uint8')
+    end
+
     it "should receive the name" do
       expect(event["name"]).to eq('pageviews')
     end


### PR DESCRIPTION
Previously, parse_data() in gmondpacket.rb checked data type from the 'type' field in the metadata of the packet but we shouldn't do that because I've reallized that some libraries is sending a integer or float metric as string.
We can see like that in some libraries below 
- https://github.com/ganglia/gmetric4j/blob/1.0.1/src/main/java/info/ganglia/gmetric4j/gmetric/Protocolv31x.java#L135
- https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-python/gmetric.py#L138
- https://github.com/ganglia/ganglia_contrib/blob/master/gmetric-java/src/java/info/ganglia/metric/type/GMetricFloat.java#L97

So, I made the packet types more detailed refers to https://github.com/ganglia/monitor-core/blob/c74feb0e96d5a3efc3c788b37c113520234ab717/lib/gm_protocol.x#L103

And I also add 'name' and 'val' field to the data from the packet. 
