### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -32,7 +32,6 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
   public
   def run(output_queue)
-    @current_thread = Thread.current
     begin
       udp_listener(output_queue)
     rescue => e

--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -40,7 +40,7 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
         @logger.warn("ganglia udp listener died",
                      :address => "#{@host}:#{@port}", :exception => e,
         :backtrace => e.backtrace)
-        Stud.stoppable_sleep(5)
+        Stud.stoppable_sleep(5) { stop? }
         retry
       end
     end # begin
@@ -85,7 +85,6 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
   public
   def close
     super
-    Stud.stop!
     close_udp
   end
 

--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -82,8 +82,7 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
   private
 
   public
-  def close
-    super
+  def stop
     close_udp
   end
 

--- a/logstash-input-ganglia.gemspec
+++ b/logstash-input-ganglia.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -13,6 +13,12 @@ describe LogStash::Inputs::Ganglia do
     expect { plugin.register }.to_not raise_error
   end
 
+  describe "when interrupting the plugin" do
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { {} }
+    end
+  end
+
   describe "connection" do
     let(:nevents)  { 10 }
     let(:port)     { rand(1000)+1025 }

--- a/spec/inputs/ganglia_spec.rb
+++ b/spec/inputs/ganglia_spec.rb
@@ -21,7 +21,7 @@ describe LogStash::Inputs::Ganglia do
 
   describe "connection" do
     let(:nevents)  { 10 }
-    let(:port)     { rand(1000)+1025 }
+    let(:port)     { rand(1024..65532) }
 
     let(:conf) do
       <<-CONFIG


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fix #9 