### PR TITLE
add ganglia metric name and value to property object

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -111,7 +111,7 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       # Check if it was a valid data request
       return nil unless data
-      props={ "program" => "ganglia", "log_host" => data["hostname"] }
+      props={ "program" => "ganglia", "log_host" => data["hostname"], "val" => data["val"], "name" => data["name"] }
       %w{dmax tmax slope type units}.each do |info|
         props[info] = @metadata[data["name"]][info]
       end


### PR DESCRIPTION
I found this plugin has missed ganglia metric value and name information that i needed.

so i changed ganglia.rb file (a very small change)
(name as "name" attribute, value as "val" attribute)

I hope this change can help someone in trouble.

I tested this code in my test-bed and it works fine. (index created on elasticsearch and can listed in kibana)

thank you.

ps) component versions
elasticsearch : 2.1.0
logstash : 2.1.1
kibana : 4.3.0
